### PR TITLE
Add a .gitattributes to support wiki format on Windows 

### DIFF
--- a/FitNesseRoot/.gitattributes
+++ b/FitNesseRoot/.gitattributes
@@ -1,0 +1,1 @@
+*.wiki text eol=lf


### PR DESCRIPTION
Page properties on initial load of the new wiki files aren't recognized:
<img width="552" alt="page properties not recognized" src="https://user-images.githubusercontent.com/26714288/27796428-3b42e2ce-600a-11e7-9b37-110a427cb1ed.png">

Adding the .gitattributes on FitNesseRoot fixes this. Had to do the following as well as I already had the project checked out:
'git rm -rf --cached .'
'git reset --hard HEAD'