### PR TITLE
Fix running test from wiki

### DIFF
--- a/FitNesseRoot/PlugIns/JdbcSlim/Installation.wiki
+++ b/FitNesseRoot/PlugIns/JdbcSlim/Installation.wiki
@@ -1,7 +1,7 @@
 #Copyright (C) 2015 by six42, All rights reserved. Contact the author via http://github.com/six42
 #
 !2 Download the latest Jdbc Slim library from github.com/six42/jdbcslim
-!define JdbcSlimLib {jdbcslim-*.jar}
+!define JdbcSlimLib {jdbcslim*.jar}
 
 !2  Installation Path 
 Adujust the below path if you installed at a different location


### PR DESCRIPTION
The generated .jar file (via ant or maven), does not have a '-' in its name. That causes it not to be found when running tests via the wiki.
This pull request addresses that.