### PR TITLE
fixed not closed statements

### DIFF
--- a/src/main/java/six42/fitnesse/jdbcslim/SQLCommand.java
+++ b/src/main/java/six42/fitnesse/jdbcslim/SQLCommand.java
@@ -160,7 +160,7 @@ public class SQLCommand extends SheetCommandBase {
     
     getOutputParameterValues(cstmt, resultTable, outputParamterMap);   
 
-
+    cstmt.close();
     
     // Only empty header columns? - then remove the (top 2) empty rows
     if(resultTable.get(0).isEmpty()){


### PR DESCRIPTION
Not closing statements cause in Oracle Db exceptions when the maximum open cursors number (default 300) exceeded:
```
Database execution failed:ORA-01000: maximum open cursors exceeded
```
Can be easily reproduced with:
 - [Oracle Db Docker](https://hub.docker.com/r/epiclabs/docker-oracle-xe-11g/)
 - This test: [TestExceedingMaxCursorsNumber.wiki](https://drive.google.com/open?id=1LR1v4mnAOVCx-dUbQ3TPOGvMHnISt43F) 
 - The related db user for the test.

With default configuration, fixtures stop to work after the 300th sql command. 

Closing the statement prevent this behaviour releasing the cursor.

p.s.: this happen with reusable connections. With Oracle Db and "single" connection fixtures fail before 300 calls because max connections number exceeded