### PR TITLE
Here should be !=1, since we must have only one element in the list.

### DIFF
--- a/src/main/java/six42/fitnesse/jdbcslim/SheetFixture.java
+++ b/src/main/java/six42/fitnesse/jdbcslim/SheetFixture.java
@@ -161,7 +161,7 @@ public class SheetFixture {
 					// Command without results
 					Line.add("pass:" + LineCommand);
 				}
-				if (LineResultSheet.size() !=2){
+				if (LineResultSheet.size() !=1){
 					Line.add("fail:" + LineCommand);
 					Line.add("fail:Got " + LineResultSheet.size() + " result rows; expected exactly one: "+ commandExecuter.rawResult());
 				}else{


### PR DESCRIPTION
During a simple select guid fron myTable limit 1 (for example) 
I get exactly one row, but I get the error message
"Got 1 result rows; expected exactly one: [[guid]]"
I proposed a fix in my pull request.
Thank you for your time.

Francesco